### PR TITLE
Display correct actor name

### DIFF
--- a/legged_gym/envs/a1/a1_config.py
+++ b/legged_gym/envs/a1/a1_config.py
@@ -62,6 +62,7 @@ class A1RoughCfg( LeggedRobotCfg ):
 
     class asset( LeggedRobotCfg.asset ):
         file = '{LEGGED_GYM_ROOT_DIR}/resources/robots/a1/urdf/a1.urdf'
+        name = "a1"
         foot_name = "foot"
         penalize_contacts_on = ["thigh", "calf"]
         terminate_after_contacts_on = ["base"]

--- a/legged_gym/envs/anymal_b/anymal_b_config.py
+++ b/legged_gym/envs/anymal_b/anymal_b_config.py
@@ -33,6 +33,7 @@ from legged_gym.envs import AnymalCRoughCfg, AnymalCRoughCfgPPO
 class AnymalBRoughCfg( AnymalCRoughCfg ):
     class asset( AnymalCRoughCfg.asset ):
         file = '{LEGGED_GYM_ROOT_DIR}/resources/robots/anymal_b/urdf/anymal_b.urdf'
+        name = "anymal_b"
         foot_name = 'FOOT'
     class rewards( AnymalCRoughCfg.rewards ):
         class scales ( AnymalCRoughCfg.rewards.scales ):

--- a/legged_gym/envs/anymal_c/mixed_terrains/anymal_c_rough_config.py
+++ b/legged_gym/envs/anymal_c/mixed_terrains/anymal_c_rough_config.py
@@ -70,6 +70,7 @@ class AnymalCRoughCfg( LeggedRobotCfg ):
 
     class asset( LeggedRobotCfg.asset ):
         file = "{LEGGED_GYM_ROOT_DIR}/resources/robots/anymal_c/urdf/anymal_c.urdf"
+        name = "anymal_c"
         foot_name = "FOOT"
         penalize_contacts_on = ["SHANK", "THIGH"]
         terminate_after_contacts_on = ["base"]

--- a/legged_gym/envs/base/legged_robot.py
+++ b/legged_gym/envs/base/legged_robot.py
@@ -677,14 +677,14 @@ class LeggedRobot(BaseTask):
                 
             rigid_shape_props = self._process_rigid_shape_props(rigid_shape_props_asset, i)
             self.gym.set_asset_rigid_shape_properties(robot_asset, rigid_shape_props)
-            anymal_handle = self.gym.create_actor(env_handle, robot_asset, start_pose, "anymal", i, self.cfg.asset.self_collisions, 0)
+            actor_handle = self.gym.create_actor(env_handle, robot_asset, start_pose, self.cfg.asset.name, i, self.cfg.asset.self_collisions, 0)
             dof_props = self._process_dof_props(dof_props_asset, i)
-            self.gym.set_actor_dof_properties(env_handle, anymal_handle, dof_props)
-            body_props = self.gym.get_actor_rigid_body_properties(env_handle, anymal_handle)
+            self.gym.set_actor_dof_properties(env_handle, actor_handle, dof_props)
+            body_props = self.gym.get_actor_rigid_body_properties(env_handle, actor_handle)
             body_props = self._process_rigid_body_props(body_props, i)
-            self.gym.set_actor_rigid_body_properties(env_handle, anymal_handle, body_props, recomputeInertia=True)
+            self.gym.set_actor_rigid_body_properties(env_handle, actor_handle, body_props, recomputeInertia=True)
             self.envs.append(env_handle)
-            self.actor_handles.append(anymal_handle)
+            self.actor_handles.append(actor_handle)
 
         self.feet_indices = torch.zeros(len(feet_names), dtype=torch.long, device=self.device, requires_grad=False)
         for i in range(len(feet_names)):

--- a/legged_gym/envs/base/legged_robot_config.py
+++ b/legged_gym/envs/base/legged_robot_config.py
@@ -98,6 +98,7 @@ class LeggedRobotCfg(BaseConfig):
 
     class asset:
         file = ""
+        name = "legged_robot"  # actor name
         foot_name = "None" # name of the feet bodies, used to index body state and contact force tensors
         penalize_contacts_on = []
         terminate_after_contacts_on = []

--- a/legged_gym/envs/cassie/cassie_config.py
+++ b/legged_gym/envs/cassie/cassie_config.py
@@ -74,6 +74,7 @@ class CassieRoughCfg( LeggedRobotCfg ):
         
     class asset( LeggedRobotCfg.asset ):
         file = '{LEGGED_GYM_ROOT_DIR}/resources/robots/cassie/urdf/cassie.urdf'
+        name = "cassie"
         foot_name = 'toe'
         terminate_after_contacts_on = ['pelvis']
         flip_visual_attachments = False


### PR DESCRIPTION
The actor name "anymal" was hardcoded so it was always displayed no matter the task (robot) was run. This pull request changes that by specifying the name in the asset class.