### PR TITLE
Sort by last-modified when resuming training

### DIFF
--- a/legged_gym/utils/helpers.py
+++ b/legged_gym/utils/helpers.py
@@ -102,9 +102,8 @@ def parse_sim_params(args, cfg):
 
 def get_load_path(root, load_run=-1, checkpoint=-1):
     try:
-        runs = os.listdir(root)
-        #TODO sort by date to handle change of month
-        runs.sort()
+        runs = sorted(os.listdir(root),
+                      key=lambda x: os.path.getctime(os.path.join(root, x)))
         if 'exported' in runs: runs.remove('exported')
         last_run = os.path.join(root, runs[-1])
     except:


### PR DESCRIPTION
Fix the loading to sort by last-modified metadata (`ctime`) instead of alphabetically, so it doesn't load the wrong folder when the month changes.