### PR TITLE
Fix projected gravity calculation in legged_robot.py

### DIFF
--- a/legged_gym/envs/base/legged_robot.py
+++ b/legged_gym/envs/base/legged_robot.py
@@ -117,7 +117,7 @@ class LeggedRobot(BaseTask):
         self.base_quat[:] = self.root_states[:, 3:7]
         self.base_lin_vel[:] = quat_rotate_inverse(self.base_quat, self.root_states[:, 7:10])
         self.base_ang_vel[:] = quat_rotate_inverse(self.base_quat, self.root_states[:, 10:13])
-        self.projected_gravity[:] = quat_rotate_inverse(self.base_quat, self.gravity_vec)
+        self.projected_gravity[:] = quat_rotate(self.base_quat, self.gravity_vec)
 
         self._post_physics_step_callback()
 


### PR DESCRIPTION
(Update legged_robot.py)

The misfunction for calculating projected gravity should be resolved by changing `quat_rotate_inverse` to the `quat_rotate` function for calculating the projected_gravity vector.