### PR TITLE
Expose log root

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ Paper: https://arxiv.org/abs/2109.11978
     -  To run on CPU add following arguments: `--sim_device=cpu`, `--rl_device=cpu` (sim on CPU and rl on GPU is possible).
     -  To run headless (no rendering) add `--headless`.
     - **Important**: To improve performance, once the training starts press `v` to stop the rendering. You can then enable it later to check the progress.
-    - The trained policy is saved in `issacgym_anymal/logs/<experiment_name>/<date_time>_<run_name>/model_<iteration>.pt`. Where `<experiment_name>` and `<run_name>` are defined in the train config.
+    - The trained policy is saved in `<log_root>/logs/<experiment_name>/<date_time>_<run_name>/model_<iteration>.pt`. Where `<experiment_name>` and `<run_name>` are defined in the train config.
     -  The following command line arguments override the values set in the config files:
      - --task TASK: Task name.
+     - --log_root: Path where policy and logs are saved. `legged_gym` per default. 
      - --resume:   Resume training from a checkpoint
      - --experiment_name EXPERIMENT_NAME: Name of the experiment to run or load.
      - --run_name RUN_NAME:  Name of the run.

--- a/legged_gym/scripts/play.py
+++ b/legged_gym/scripts/play.py
@@ -55,7 +55,7 @@ def play(args):
     obs = env.get_observations()
     # load policy
     train_cfg.runner.resume = True
-    ppo_runner, train_cfg = task_registry.make_alg_runner(env=env, name=args.task, args=args, train_cfg=train_cfg)
+    ppo_runner, train_cfg = task_registry.make_alg_runner(env=env, name=args.task, args=args, train_cfg=train_cfg, log_root=args.log_root)
     policy = ppo_runner.get_inference_policy(device=env.device)
     
     # export policy as a jit module (used to run it from C++)

--- a/legged_gym/scripts/train.py
+++ b/legged_gym/scripts/train.py
@@ -39,7 +39,7 @@ import torch
 
 def train(args):
     env, env_cfg = task_registry.make_env(name=args.task, args=args)
-    ppo_runner, train_cfg = task_registry.make_alg_runner(env=env, name=args.task, args=args)
+    ppo_runner, train_cfg = task_registry.make_alg_runner(env=env, name=args.task, args=args, log_root=args.log_root)
     ppo_runner.learn(num_learning_iterations=train_cfg.runner.max_iterations, init_at_random_ep_len=True)
 
 if __name__ == '__main__':

--- a/legged_gym/utils/helpers.py
+++ b/legged_gym/utils/helpers.py
@@ -152,6 +152,7 @@ def update_cfg_from_args(env_cfg, cfg_train, args):
 def get_args():
     custom_parameters = [
         {"name": "--task", "type": str, "default": "anymal_c_flat", "help": "Resume training or start testing from a checkpoint. Overrides config file if provided."},
+        {"name": "--log_root", "type": str,  "default": "default", "help": "Parent path of where experiment logs are written."},
         {"name": "--resume", "action": "store_true", "default": False,  "help": "Resume training from a checkpoint"},
         {"name": "--experiment_name", "type": str,  "help": "Name of the experiment to run or load. Overrides config file if provided."},
         {"name": "--run_name", "type": str,  "help": "Name of the run. Overrides config file if provided."},


### PR DESCRIPTION
Expose the log root directory as an option that can be set via the command line. This facilitates e.g. training on multiple machines while saving the logs in a central place.  