### PR TITLE
Fixed the number of rows set for terrain parameters

### DIFF
--- a/legged_gym/envs/base/legged_robot.py
+++ b/legged_gym/envs/base/legged_robot.py
@@ -583,8 +583,8 @@ class LeggedRobot(BaseTask):
         hf_params.column_scale = self.terrain.cfg.horizontal_scale
         hf_params.row_scale = self.terrain.cfg.horizontal_scale
         hf_params.vertical_scale = self.terrain.cfg.vertical_scale
-        hf_params.nbRows = self.terrain.tot_cols
-        hf_params.nbColumns = self.terrain.tot_rows 
+        hf_params.nbRows = self.terrain.tot_rows
+        hf_params.nbColumns = self.terrain.tot_cols
         hf_params.transform.p.x = -self.terrain.cfg.border_size 
         hf_params.transform.p.y = -self.terrain.cfg.border_size
         hf_params.transform.p.z = 0.0


### PR DESCRIPTION
nbRows and nbColumns are assigned in the correct order.
./ legged_robot.py
hf_params.nbRows = self.terrain.tot_cols         ->        hf_params.nbRows = self.terrain.tot_rows
hf_params.nbColumns = self.terrain.tot_rows  ->        hf_params.nbColumns = self.terrain.tot_cols
