### PR TITLE
Update link to Isaac Lab's Locomotion resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It includes all components needed for sim-to-real transfer: actuator network, fr
 
 With the shift from Isaac Gym to Isaac Sim at NVIDIA, we have migrated all the environments from this work to [Isaac Lab](https://github.com/isaac-sim/IsaacLab). Following this migration, this repository will receive limited updates and support. We encourage all users to migrate to the new framework for their applications.
 
-Information about this work's locomotion-related tasks in Isaac Lab is available [here](https://isaac-sim.github.io/IsaacLab/source/features/environments.html#locomotion).
+Information about this work's locomotion-related tasks in Isaac Lab is available [here](https://isaac-sim.github.io/IsaacLab/main/source/overview/environments.html#locomotion).
 
 ---
 


### PR DESCRIPTION
## Changes Made

I've updated the link that points to the Isaac Lab's Locomotion resources in the README file.

## Reason for Changes

The previous link was outdated/broken, and I've replaced it with the current working URL to ensure users can access the correct Locomotion resources from Isaac Lab.

## Details

+ Updated link in the README.md file

+ Maintained the same link text/description

+ Verified the new link redirects to the correct resource

This small change improves documentation quality by ensuring all references are current and functional.